### PR TITLE
Fix #16 and add unit test

### DIFF
--- a/lib/introspect/assetdeclaration.js
+++ b/lib/introspect/assetdeclaration.js
@@ -54,7 +54,8 @@ class AssetDeclaration extends ClassDeclaration {
      * @return {string} the short name of the base system type
      */
     getSystemType() {
-        return this.modelFile.getModelManager().getSystemModelTable().get('Asset');
+        let systemType = this.modelFile.getModelManager().getSystemModelTable().get('Asset');
+        return systemType !== undefined ? systemType : null;
     }
 }
 

--- a/lib/introspect/eventdeclaration.js
+++ b/lib/introspect/eventdeclaration.js
@@ -40,7 +40,8 @@ class EventDeclaration extends ClassDeclaration {
      * @return {string} the short name of the base system type
      */
     getSystemType() {
-        return this.modelFile.getModelManager().getSystemModelTable().get('Event');
+        let systemType = this.modelFile.getModelManager().getSystemModelTable().get('Event');
+        return systemType !== undefined ? systemType : null;
     }
 
     /**
@@ -56,7 +57,7 @@ class EventDeclaration extends ClassDeclaration {
 
         // If using models without importing system models
         try {
-            this.getModelFile().getType(this.getSystemType());
+            systemTypeDeclared = this.getModelFile().getType(this.getSystemType()) !== null;
         } catch (e) {
             systemTypeDeclared = false;
         }

--- a/lib/introspect/eventdeclaration.js
+++ b/lib/introspect/eventdeclaration.js
@@ -57,9 +57,13 @@ class EventDeclaration extends ClassDeclaration {
 
         // If using models without importing system models
         try {
-            systemTypeDeclared = this.getModelFile().getType(this.getSystemType()) !== null;
+            this.getModelFile().getType(this.getSystemType());
         } catch (e) {
             systemTypeDeclared = false;
+        }
+        if(systemTypeDeclared){
+            const hasSystemType = this.getSystemType() !== null;
+            systemTypeDeclared = hasSystemType;
         }
 
         if (!this.isSystemType() && this.idField && systemTypeDeclared) {

--- a/lib/introspect/participantdeclaration.js
+++ b/lib/introspect/participantdeclaration.js
@@ -49,7 +49,8 @@ class ParticipantDeclaration extends ClassDeclaration {
      * @return {string} the short name of the base system type
      */
     getSystemType() {
-        return this.modelFile.getModelManager().getSystemModelTable().get('Participant');
+        let systemType = this.modelFile.getModelManager().getSystemModelTable().get('Participant');
+        return systemType !== undefined ? systemType : null;
     }
 }
 

--- a/lib/introspect/transactiondeclaration.js
+++ b/lib/introspect/transactiondeclaration.js
@@ -66,6 +66,7 @@ class TransactionDeclaration extends ClassDeclaration {
             const hasSystemType = this.getSystemType() !== null;
             systemTypeDeclared = hasSystemType;
         }
+
         if (!this.isSystemType() && this.idField && systemTypeDeclared) {
             throw new IllegalModelException('Transaction should not specify an identifying field.', this.modelFile, this.ast.location);
         }

--- a/lib/introspect/transactiondeclaration.js
+++ b/lib/introspect/transactiondeclaration.js
@@ -41,7 +41,8 @@ class TransactionDeclaration extends ClassDeclaration {
      * @return {string} the short name of the base system type
      */
     getSystemType() {
-        return this.modelFile.getModelManager().getSystemModelTable().get('Transaction');
+        let systemType = this.modelFile.getModelManager().getSystemModelTable().get('Transaction');
+        return systemType !== undefined ? systemType : null;
     }
 
     /**
@@ -61,7 +62,10 @@ class TransactionDeclaration extends ClassDeclaration {
         } catch (e) {
             systemTypeDeclared = false;
         }
-
+        if(systemTypeDeclared){
+            const hasSystemType = this.getSystemType() !== null;
+            systemTypeDeclared = hasSystemType;
+        }
         if (!this.isSystemType() && this.idField && systemTypeDeclared) {
             throw new IllegalModelException('Transaction should not specify an identifying field.', this.modelFile, this.ast.location);
         }

--- a/test/data/model/carlease-nosystem.cto
+++ b/test/data/model/carlease-nosystem.cto
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Car Lease Scenario
+ * composer Language File
+ *
+ * Author: Billy Blockchain
+ * Version: 1.0
+ * Last Updates: 2016-09-22
+ */
+
+// define the namespace for this model
+namespace org.acme
+
+// define an enumeration
+enum State {
+    o CREATED
+    o REGISTERED
+    o SOLD
+}
+
+concept Person {
+    o String firstName
+    o String lastName
+}
+
+concept Address {
+    o String city default="Winchester"
+    o String country optional
+    o String state optional
+    o String street optional
+    o String zip optional
+}
+
+concept Customer extends Person {
+    o Address address
+}
+
+/**
+ * MyParticipant defines an actor in a blockchain based business network
+ */
+participant MyParticipant identified by id {
+  o String id
+}
+
+/**
+ * Define an asset base class. Because this is an abstract asset
+ * we also declare the name of the field that will identify the instances.
+ */
+abstract asset Base identified by vin {
+    // The identifying field must be a String
+    // Optinally use a regular expression to validate the contents of the field
+    o String vin regex = /^[A-HJ-NPR-Z]{8}[X][A-HJ-NPR-Z]{2}\d{6}$/
+}
+
+/**
+ * Vehicle is the definition of an asset that we will be tracking
+ * Vehicle extends (augments) the Base asset. The identifying field has already
+ * been declared, so we do not redeclare it here.
+ */
+asset Vehicle extends Base {
+  // An asset contains Fields, each of which can have an optional default value
+  o String model default="F150"
+  o String make default="FORD"
+  o String reg default="ABC123"
+  // A numeric field can have a range validation expression
+  o Integer year default=2016 range=[1990,] optional // model year must be 1990 or higher
+  o Integer[] integerArray
+  o State state
+  o Double value
+  o String colour
+  o String V5cID regex=/^[A-z][A-z][0-9]{7}/
+  o String LeaseContractID
+  o Boolean scrapped default=false
+  o DateTime lastUpdate optional
+  --> MyParticipant owner //relationship to a MyParticipant, with the field named 'owner'.
+  --> MyParticipant[] previousOwners optional // Nary relationship
+  o Customer customer
+}
+
+participant Regulator extends MyParticipant {
+
+}
+
+// defines a Vehicle transaction type
+transaction VehicleTransaction identified by transactionId  {
+  o String transactionId
+	--> Vehicle vehicle // a VehicleTransaction is related to a Vehicle
+}
+
+transaction VehicleCreated extends VehicleTransaction {
+}
+
+transaction VehicleScrapped extends VehicleTransaction{
+}
+
+event TestEvent identified by eventId {
+ o String eventId
+}

--- a/test/introspect/transactiondeclaration.js
+++ b/test/introspect/transactiondeclaration.js
@@ -75,15 +75,5 @@ describe('TransactionDeclaration', () => {
                 td.validate();
             }).should.throw(/Transaction should not specify an identifying field./);
         });
-
-        it('should throw if transaction specifies and identifying field', () => {
-            const introspectUtils = new IntrospectUtils();
-            let asset = introspectUtils.loadLastDeclaration('test/data/parser/transactiondeclaration.definesidentifier.cto', TransactionDeclaration);
-            (() => {
-                asset.validate();
-            }).should.throw(/Transaction should not specify an identifying field./);
-        });
-
     });
-
 });

--- a/test/models/nosystemmodels.js
+++ b/test/models/nosystemmodels.js
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+require('chai').should();
+const ModelManager = require('../../lib/modelmanager');
+
+const fs = require('fs');
+
+describe('No System Models', function() {
+    describe('#getModelManager', function() {
+        it('check parsing and model manager', function() {
+            let modelManager = new ModelManager();
+            modelManager.should.not.be.null;
+
+            // parse a model file from disk and add to the ModelManager
+            let fileName = './test/data/model/carlease-nosystem.cto';
+            let carLeaseModel = fs.readFileSync(fileName, 'utf8');
+            carLeaseModel.should.not.be.null;
+            modelManager.addModelFile(carLeaseModel,fileName);
+
+            let carLeaseModelFile = modelManager.getModelFile('org.acme');
+            carLeaseModelFile.getNamespace().should.equal('org.acme');
+            carLeaseModelFile.getAssetDeclarations().length.should.equal(2);
+            carLeaseModelFile.getTransactionDeclarations().length.should.equal(3);
+            carLeaseModelFile.getEventDeclarations().length.should.equal(1);
+            carLeaseModelFile.getParticipantDeclarations().length.should.equal(2);
+        });
+    });
+});


### PR DESCRIPTION
Fixes #16 . 

This allows users to add Concerto to their project without specifying a system model. This implies that all base types (Transaction, Event, Asset & Participant) will need to specify an identifying field when a system model is not provided