### PR TITLE
(fix) pkgstamp script should use moment-mini as well

### DIFF
--- a/scripts/pkgstamp.js
+++ b/scripts/pkgstamp.js
@@ -16,7 +16,7 @@
 'use strict';
 
 const fs = require('fs');
-const moment = require('moment');
+const moment = require('moment-mini');
 const path = require('path');
 
 const timestamp = moment().format('YYYYMMDDHHmmss');


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

<!--- Provide a general summary of the pull request in the Title above -->

## Checklist
 - [ ]  A link to the issue/user story that the pull request relates to
 - [ ]  How to recreate the problem without the fix
 - [x]  Design of the fix
 - [ ]  How to prove that the fix works
 - [ ]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?


## Issue/User story

## Steps to Reproduce
In travis

## Existing issues

N/A

## Design of the fix

Update script pkgstamp to use `moment-mini`

## Validation of the fix

Not easy to test without merge and test on travis

## Automated Tests

Only affects deployment scripts

## What documentation has been provided for this pull request
