### PR TITLE
feat(modelmanager): Gracefully handle missing external models

### DIFF
--- a/lib/introspect/loaders/modelfiledownloader.js
+++ b/lib/introspect/loaders/modelfiledownloader.js
@@ -71,6 +71,11 @@ class ModelFileDownloader extends JobQueue {
             });
 
             this.on('queueError', (error, jobQueue) => {
+                if(error.response && error.response.status && error.response.status !== 200){
+                    const err = new Error(`Unable to download external model dependency '${jobQueue[0].url}'. Are you connected to the internet?`);
+                    err.code = 'MISSING_DEPENDENCY';
+                    return reject(err);
+                }
                 reject(new Error('Failed to load model file. Queue: ' + jobQueue + ' Details: ' + error));
             });
 

--- a/lib/introspect/loaders/modelfiledownloader.js
+++ b/lib/introspect/loaders/modelfiledownloader.js
@@ -72,7 +72,7 @@ class ModelFileDownloader extends JobQueue {
 
             this.on('queueError', (error, jobQueue) => {
                 if(error.response && error.response.status && error.response.status !== 200){
-                    const err = new Error(`Unable to download external model dependency '${jobQueue[0].url}'. Are you connected to the internet?`);
+                    const err = new Error(`Unable to download external model dependency '${jobQueue[0].url}'`);
                     err.code = 'MISSING_DEPENDENCY';
                     return reject(err);
                 }

--- a/lib/modelmanager.js
+++ b/lib/modelmanager.js
@@ -307,7 +307,7 @@ class ModelManager {
      * @throws {IllegalModelException} if the models fail validation
      * @return {Promise} a promise when the download and update operation is completed.
      */
-    updateExternalModels(options, modelFileDownloader) {
+    async updateExternalModels(options, modelFileDownloader) {
 
         const NAME = 'updateExternalModels';
         debug(NAME, 'updateExternalModels', options);
@@ -316,30 +316,49 @@ class ModelManager {
             modelFileDownloader = new ModelFileDownloader(new DefaultModelFileLoader(this));
         }
 
-        return modelFileDownloader.downloadExternalDependencies(this.getModelFiles(), options)
-            .then((externalModelFiles) => {
-                const originalModelFiles = {};
-                Object.assign(originalModelFiles, this.modelFiles);
-
-                try {
-                    externalModelFiles.forEach((mf) => {
-                        const existing = this.modelFiles[mf.getNamespace()];
-
-                        if (existing) {
-                            this.updateModelFile(mf, mf.getName(), true); // disable validation
-                        } else {
-                            this.addModelFile(mf, mf.getName(), true); // disable validation
-                        }
-                    });
-
-                    // now everything is applied, we need to revalidate all models
-                    this.validateModelFiles();
-                } catch (err) {
-                    this.modelFiles = {};
-                    Object.assign(this.modelFiles, originalModelFiles);
-                    throw err;
+        const externalModelFiles = await modelFileDownloader.downloadExternalDependencies(this.getModelFiles(), options)
+            .catch(error => {
+                // If we're not able to download the latest dependencies, see whether the models all validate based on the available cached models.
+                if(error.code === 'MISSING_DEPENDENCY'){
+                    try {
+                        this.validateModelFiles();
+                        return [];
+                    } catch (validationError){
+                        // The validation error tells us the first model that is missing from the model manager, but the dependency download
+                        // will fail at the first external model, regardless of whether there is already a local copy.
+                        // As a hint to the user we display the URL of the external model that can't be found.
+                        const namespace = validationError.shortMessage.trim().split(' ').pop(); // Hack to parse the namespace from the error message
+                        const url = validationError.getModelFile().getImportURI(namespace);
+                        const err = new Error(`Unable to download external model dependency '${url}'. Are you connected to the internet?`);
+                        err.code = 'MISSING_DEPENDENCY';
+                        throw err;
+                    }
+                } else {
+                    throw error;
                 }
             });
+        const originalModelFiles = {};
+        Object.assign(originalModelFiles, this.modelFiles);
+
+        try {
+            externalModelFiles.forEach((mf) => {
+                const existing = this.modelFiles[mf.getNamespace()];
+
+                if (existing) {
+                    this.updateModelFile(mf, mf.getName(), true); // disable validation
+                } else {
+                    this.addModelFile(mf, mf.getName(), true); // disable validation
+                }
+            });
+
+            // now everything is applied, we need to revalidate all models
+            this.validateModelFiles();
+            return externalModelFiles;
+        } catch (err) {
+            this.modelFiles = {};
+            Object.assign(this.modelFiles, originalModelFiles);
+            throw err;
+        }
     }
 
     /**

--- a/lib/modelmanager.js
+++ b/lib/modelmanager.js
@@ -329,7 +329,7 @@ class ModelManager {
                         // As a hint to the user we display the URL of the external model that can't be found.
                         const namespace = validationError.shortMessage.trim().split(' ').pop(); // Hack to parse the namespace from the error message
                         const url = validationError.getModelFile().getImportURI(namespace);
-                        const err = new Error(`Unable to download external model dependency '${url}'. Are you connected to the internet?`);
+                        const err = new Error(`Unable to download external model dependency '${url}'`);
                         err.code = 'MISSING_DEPENDENCY';
                         throw err;
                     }

--- a/lib/modelmanager.js
+++ b/lib/modelmanager.js
@@ -327,8 +327,10 @@ class ModelManager {
                         // The validation error tells us the first model that is missing from the model manager, but the dependency download
                         // will fail at the first external model, regardless of whether there is already a local copy.
                         // As a hint to the user we display the URL of the external model that can't be found.
-                        const namespace = validationError.shortMessage.trim().split(' ').pop(); // Hack to parse the namespace from the error message
-                        const url = validationError.getModelFile().getImportURI(namespace);
+                        const modelFile = validationError.getModelFile();
+                        const namespaces = modelFile.getExternalImports();
+                        const missingNs = Object.keys(namespaces).find((ns) => validationError.shortMessage.includes(ns));
+                        const url = modelFile.getImportURI(missingNs);
                         const err = new Error(`Unable to download external model dependency '${url}'`);
                         err.code = 'MISSING_DEPENDENCY';
                         throw err;

--- a/package-lock.json
+++ b/package-lock.json
@@ -534,7 +534,7 @@
     },
     "axios": {
       "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
       "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
       "requires": {
         "follow-redirects": "^1.3.0",
@@ -699,13 +699,13 @@
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
       "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
       "dev": true
     },
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
       "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
       "dev": true
     },
@@ -1271,7 +1271,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -1308,7 +1308,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -1350,7 +1350,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
@@ -1483,7 +1483,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
@@ -1502,7 +1502,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -1746,7 +1746,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -1759,7 +1759,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -1910,7 +1910,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -3784,7 +3784,7 @@
     },
     "jsonfile": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "requires": {
         "graceful-fs": "^4.1.6"
@@ -3833,7 +3833,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
@@ -3956,7 +3956,7 @@
     },
     "marked": {
       "version": "0.3.19",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+      "resolved": "http://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
       "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
       "dev": true
     },
@@ -4050,7 +4050,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mississippi": {
@@ -4106,7 +4106,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -4114,7 +4114,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
@@ -4140,7 +4140,7 @@
       "dependencies": {
         "commander": {
           "version": "2.15.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
           "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
           "dev": true
         },
@@ -4478,8 +4478,7 @@
         },
         "commander": {
           "version": "2.17.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "commondir": {
           "version": "1.0.1",
@@ -5243,8 +5242,7 @@
           "dependencies": {
             "source-map": {
               "version": "0.6.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -5666,7 +5664,7 @@
     },
     "pegjs": {
       "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
+      "resolved": "http://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
       "integrity": "sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0=",
       "dev": true
     },
@@ -5932,7 +5930,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
@@ -6268,7 +6266,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
@@ -6622,7 +6620,7 @@
     },
     "table": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/table/-/table-4.0.3.tgz",
       "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
       "dev": true,
       "requires": {
@@ -6679,7 +6677,7 @@
     },
     "text-encoding": {
       "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
       "dev": true
     },
@@ -6691,7 +6689,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -7251,7 +7249,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",
@@ -7283,7 +7281,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"

--- a/test/modelmanager.js
+++ b/test/modelmanager.js
@@ -619,7 +619,41 @@ concept Bar {
             modelManager.getModelFile('org.acme').should.not.be.null;
 
             // import all external models
-            return modelManager.updateExternalModels().should.be.rejectedWith(Error, 'Failed to load model file');
+            return modelManager.updateExternalModels().should.be.rejectedWith(Error, 'Unable to download external model dependency \'github://external.cto\'. Are you connected to the internet?');
+        });
+
+        it('should fail using bad protocol and default model file loader', () => {
+
+            // disable validation, we are using an external model
+            modelManager.addModelFile(`namespace org.acme
+import org.external.* from foo://external.cto
+
+concept Bar {
+    o Foo foo
+}`, 'internal.cto', true);
+            modelManager.getModelFile('org.acme').should.not.be.null;
+
+            // import all external models
+            return modelManager.updateExternalModels().should.be.rejectedWith(Error, 'Failed to find a model file loader that can handle: foo://external.cto');
+        });
+
+        it('should not fail when an external model file can\'t be downloaded, but that isn\'t needed', () => {
+
+            // disable validation, we are using an external model
+            modelManager.addModelFile(`namespace org.acme
+import org.external.* from github://external.cto
+
+concept Bar {
+    o Foo foo
+}`, 'internal.cto', true);
+            modelManager.addModelFile(`namespace org.external
+concept Foo {
+    o String foo
+}`, 'internal.cto', true);
+            modelManager.getModelFile('org.acme').should.not.be.null;
+
+            // import all external models
+            return modelManager.updateExternalModels().should.be.fulfilled;
         });
     });
 

--- a/test/modelmanager.js
+++ b/test/modelmanager.js
@@ -619,7 +619,7 @@ concept Bar {
             modelManager.getModelFile('org.acme').should.not.be.null;
 
             // import all external models
-            return modelManager.updateExternalModels().should.be.rejectedWith(Error, 'Unable to download external model dependency \'github://external.cto\'. Are you connected to the internet?');
+            return modelManager.updateExternalModels().should.be.rejectedWith(Error, 'Unable to download external model dependency \'github://external.cto\'');
         });
 
         it('should fail using bad protocol and default model file loader', () => {


### PR DESCRIPTION
When a model manager can't find an external model (for example, because of a poorly formed URL). The existing error message is pretty cryptic and doesn't tell the user why the model manager was unable to add the new model file.

Thie PR:
- gives the user more helpful error messages, 
- adds a property to the Error object that gives a helpful error code. The error code can be used by downstream systems to detect when a model download has failed, for example when the system doesn't have a network connection.
- doesn't raise errors at all if the models validate, even if externals models can't be downloaded. For example, if there are local caches versions of the external models, or the external models are unused, the model manager is still useable now.

## Examples
As exposed through Cicero CLI.

Before
```
mattmbp:cicero-cli matt$ cicero parse --template ./acceptance-of-delivery/
22:55:16 - info: Loading a default sample.txt file.
22:55:16 - error: Failed to load model file. Queue: [object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object] Details: Error: getaddrinfo ENOTFOUND models.accordproject.org models.accordproject.org:443
```

After:
```
mattmbp:cicero-cli matt$ cicero parse --template ./acceptance-of-delivery/
22:52:58 - info: Loading a default sample.txt file.
22:52:58 - error: Unable to download external model dependency 'https://models.accordproject.org/address.cto'
```