### PR TITLE
feature(errors) Allow overriding of the full message in a parse error

### DIFF
--- a/lib/introspect/parseexception.js
+++ b/lib/introspect/parseexception.js
@@ -31,9 +31,10 @@ class ParseException extends BaseFileException {
      * @param {string} message - the message for the exception
      * @param {string} fileLocation - the optional file location associated with the exception
      * @param {string} fileName - the optional file name associated with the exception
+     * @param {string} fullMessageOverride - the optional pre-existing full message
      * @param {string} component - the optional component which throws this error
      */
-    constructor(message, fileLocation, fileName, component) {
+    constructor(message, fileLocation, fileName, fullMessageOverride, component) {
         let fullMessage = message;
         let suffix = '';
 
@@ -54,9 +55,6 @@ class ParseException extends BaseFileException {
                     }
                 }
             }
-            if (fileName && !fileLocation.fileName) {
-                fileLocation.fileName = fileName;
-            }
             if (suffix) {
                 suffix+= ' line ' + fileLocation.start.line + ' column ' + fileLocation.start.column;
             } else {
@@ -65,7 +63,7 @@ class ParseException extends BaseFileException {
         }
 
         fullMessage += suffix;
-        super(message, fileLocation, fullMessage, fileName, component);
+        super(message, fileLocation, fullMessageOverride || fullMessage, fileName, component);
     }
 }
 

--- a/lib/serializer/validationexception.js
+++ b/lib/serializer/validationexception.js
@@ -27,7 +27,7 @@ const BaseException = require('../baseexception');
 class ValidationException extends BaseException {
 
     /**
-     * Create an ParseException
+     * Create a ValidationException
      * @param {string} message - the message for the exception
      * @param {string} component - the optional component which throws this error
      */

--- a/test/introspect/parseexception.js
+++ b/test/introspect/parseexception.js
@@ -32,9 +32,11 @@ describe('ParseException', function () {
         });
 
         it('should return an instance of BaseFileException for another component', function () {
-            let exc = new ParseException('message', fileLocation, 'foo.cto', 'foo');
+            let exc = new ParseException('message', fileLocation, 'foo.cto', 'Full Message', 'foo');
             exc.should.be.an.instanceOf(BaseFileException);
-            exc.fileLocation.fileName.should.equal('foo.cto');
+            exc.fileName.should.equal('foo.cto');
+            exc.message.should.equal('Full Message');
+            exc.shortMessage.should.equal('message');
             exc.component.should.equal('foo');
         });
 
@@ -67,7 +69,7 @@ describe('ParseException', function () {
 
         it('should have a message with a file location and file name', function () {
             let exc = new ParseException('message', fileLocation, 'foo.cto');
-            exc.fileLocation.fileName.should.equal('foo.cto');
+            exc.fileName.should.equal('foo.cto');
             exc.message.should.match(/message File foo.cto line 1 column 1/);
         });
 


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

<!--- Provide a general summary of the pull request in the Title above -->

## Checklist
 - [ ]  A link to the issue/user story that the pull request relates to
 - [ ]  How to recreate the problem without the fix
 - [x]  Design of the fix
 - [ ]  How to prove that the fix works
 - [x]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?

## Issue/User story
The fix allows a user to override the default `fullMessage` in a parse error.
It also removes redundant `fileName` in `fileLocation` for `ParseException` since those are now by default in the `BaseFileException`.

## Steps to Reproduce
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug include code to reproduce, if relevant -->
1.
2.
3.
4.


## Existing issues
<!-- Have you searched for any existing issues or are their any similar issues that you've found? -->
- [ ] [Stack Overflow issues](http://stackoverflow.com/tags/hyperledger-composer)
- [ ] [GitHub Issues](https://github.com/hyperledger/composer/issues)
- [ ] [Rocket Chat history](https://chat.hyperledger.org/channel/composer)

<!-- please include any links to issues here -->

## Design of the fix
<!-- Focus on why you designed this fix this way, and what was discounted. Do not describe just the code - we can read that! -->

## Validation of the fix
<!-- Over and above the tests, what has been done to prove this works? -->

## Automated Tests
<!-- Please describe the automated tests that are put in place to stop this recurring -->

## What documentation has been provided for this pull request
<!-- JSDocs, WebSite and answers to Stack Overflow questions are possible documentation sources -->
