### PR TITLE
errors(models) remove modelfile from IllegalModelException

### DIFF
--- a/lib/introspect/illegalmodelexception.js
+++ b/lib/introspect/illegalmodelexception.js
@@ -56,15 +56,6 @@ class IllegalModelException extends BaseFileException {
         messageSuffix = messageSuffix.charAt(0).toUpperCase() + messageSuffix.slice(1);
 
         super(message, fileLocation, message + ' ' + messageSuffix, fileName, component);
-        this.modelFile = modelFile;
-    }
-
-    /**
-     * Returns the modelfile associated with the exception or null
-     * @return {ModelFule} the optional modelFile associated with this error
-     */
-    getModelFile() {
-        return this.modelFile;
     }
 }
 

--- a/lib/modelmanager.js
+++ b/lib/modelmanager.js
@@ -327,7 +327,7 @@ class ModelManager {
                         // The validation error tells us the first model that is missing from the model manager, but the dependency download
                         // will fail at the first external model, regardless of whether there is already a local copy.
                         // As a hint to the user we display the URL of the external model that can't be found.
-                        const modelFile = validationError.getModelFile();
+                        const modelFile = this.getModelFileByFileName(validationError.fileName);
                         const namespaces = modelFile.getExternalImports();
                         const missingNs = Object.keys(namespaces).find((ns) => validationError.shortMessage.includes(ns));
                         const url = modelFile.getImportURI(missingNs);
@@ -462,6 +462,20 @@ class ModelManager {
      */
     getModelFile(namespace) {
         return this.modelFiles[namespace];
+    }
+
+    /**
+     * Get the ModelFile associated with a file name
+     * Note - this is an internal method and therefore will return the system model
+     * as well as any network defined models.
+     *
+     * It is the callers responsibility to remove this before the data leaves an external API
+     * @param {string} fileName - the fileName associated with the ModelFile
+     * @return {ModelFile} registered ModelFile for the namespace or null
+     * @private
+     */
+    getModelFileByFileName(fileName) {
+        return this.getModelFiles().filter(mf => mf.getName() === fileName)[0];
     }
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -2903,8 +2903,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2925,14 +2924,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2947,20 +2944,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3077,8 +3071,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3090,7 +3083,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3105,7 +3097,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3113,14 +3104,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3139,7 +3128,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3220,8 +3208,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3233,7 +3220,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3319,8 +3305,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3356,7 +3341,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3376,7 +3360,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3420,14 +3403,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/test/introspect/illegalmodelexception.js
+++ b/test/introspect/illegalmodelexception.js
@@ -51,9 +51,9 @@ describe('IllegalModelException', function () {
             exc.message.should.match(/message File 'model.cto': line 1 column 1, to line 1 column 1./);
         });
 
-        it('should have a modelfile', function () {
+        it('should have a file name', function () {
             let exc = new IllegalModelException('message', modelFile, fileLocation);
-            exc.getModelFile().should.equal(modelFile);
+            exc.fileName.should.equal(modelFile.getName());
         });
 
         it('should have a stack trace', function () {

--- a/test/introspect/semantic_validation.js
+++ b/test/introspect/semantic_validation.js
@@ -63,7 +63,7 @@ describe('ModelFile semantic validation', () => {
                 mf.validate();
             }
             catch(error) {
-                error.getModelFile().getName().should.equal('invalid.cto');
+                error.fileName.should.equal('invalid.cto');
                 error.getFileLocation().start.line.should.equal(22);
                 error.getFileLocation().start.column.should.equal(1);
                 error.getFileLocation().end.line.should.equal(24);


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

<!--- Provide a general summary of the pull request in the Title above -->

## Checklist
 - [ ]  A link to the issue/user story that the pull request relates to
 - [ ]  How to recreate the problem without the fix
 - [x]  Design of the fix
 - [x]  How to prove that the fix works
 - [ ]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?


## Issue/User story

Exception returned by the API should not carry the whole model if possible. This removes the `modelFile` field from `IllegalModelExceptions`. `fileName` is used to retrieve the model file when needed instead.

## Steps to Reproduce
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug include code to reproduce, if relevant -->
1.
2.
3.
4.


## Existing issues
<!-- Have you searched for any existing issues or are their any similar issues that you've found? -->
- [ ] [Stack Overflow issues](http://stackoverflow.com/tags/hyperledger-composer)
- [ ] [GitHub Issues](https://github.com/hyperledger/composer/issues)
- [ ] [Rocket Chat history](https://chat.hyperledger.org/channel/composer)

<!-- please include any links to issues here -->

## Design of the fix
<!-- Focus on why you designed this fix this way, and what was discounted. Do not describe just the code - we can read that! -->

## Validation of the fix

All tests are passing as before. At least one test uses access to the model file from their name when an illegal model error occurs.

## Automated Tests
<!-- Please describe the automated tests that are put in place to stop this recurring -->

## What documentation has been provided for this pull request
<!-- JSDocs, WebSite and answers to Stack Overflow questions are possible documentation sources -->
