### PR TITLE
fix(47): Adds custom instanceof implementation to allow comparison of different module instances

### DIFF
--- a/api.txt
+++ b/api.txt
@@ -9,6 +9,7 @@ class AssetDeclaration extends ClassDeclaration {
    + void constructor(ModelFile,Object) throws IllegalModelException
    + boolean isRelationshipTarget() 
    + string getSystemType() 
+   + boolean undefined(object) 
 }
 class ClassDeclaration extends Decorated {
    + void constructor(ModelFile,string) throws IllegalModelException
@@ -36,10 +37,12 @@ class ClassDeclaration extends Decorated {
    + Property[] getProperties() 
    + Property getNestedProperty(string) throws IllegalModelException
    + String toString() 
+   + boolean undefined(object) 
 }
 class ConceptDeclaration extends ClassDeclaration {
    + void constructor(ModelFile,Object) throws IllegalModelException
    + boolean isConcept() 
+   + boolean undefined(object) 
 }
 class Decorator {
    + void constructor(Object) throws IllegalModelException
@@ -54,14 +57,17 @@ class EnumDeclaration extends ClassDeclaration {
    + void constructor(ModelFile,Object) throws IllegalModelException
    + boolean isEnum() 
    + String toString() 
+   + boolean undefined(object) 
 }
 class EnumValueDeclaration extends Property {
    + void constructor(ClassDeclaration,Object) throws IllegalModelException
+   + boolean undefined(object) 
 }
 class EventDeclaration extends ClassDeclaration {
    + void constructor(ModelFile,Object) throws IllegalModelException
    + string getSystemType() 
    + boolean isEvent() 
+   + boolean undefined(object) 
 }
 class Introspector {
    + void constructor(ModelManager) 
@@ -90,11 +96,13 @@ class ModelFile {
    + ClassDeclaration[] getAllDeclarations() 
    + string getDefinitions() 
    + boolean isSystemModelFile() 
+   + boolean undefined(object) 
 }
 class ParticipantDeclaration extends ClassDeclaration {
    + void constructor(ModelFile,Object) throws IllegalModelException
    + boolean isRelationshipTarget() 
    + string getSystemType() 
+   + boolean undefined(object) 
 }
 class Property extends Decorated {
    + void constructor(ClassDeclaration,Object) throws IllegalModelException
@@ -108,14 +116,17 @@ class Property extends Decorated {
    + boolean isArray() 
    + boolean isTypeEnum() 
    + boolean isPrimitive() 
+   + boolean undefined(object) 
 }
 class RelationshipDeclaration extends Property {
    + void constructor(ClassDeclaration,Object) throws IllegalModelException
    + String toString() 
+   + boolean undefined(object) 
 }
 class TransactionDeclaration extends ClassDeclaration {
    + void constructor(ModelFile,Object) throws IllegalModelException
    + string getSystemType() 
+   + boolean undefined(object) 
 }
 class Concept extends Typed {
    + boolean isConcept() 
@@ -178,6 +189,7 @@ class ModelManager {
    + Serializer getSerializer() 
    + DecoratorFactory[] getDecoratorFactories() 
    + void addDecoratorFactory(DecoratorFactory) 
+   + boolean undefined(object) 
 }
 class Serializer {
    + void constructor(Factory,ModelManager) 

--- a/changelog.txt
+++ b/changelog.txt
@@ -24,6 +24,9 @@
 # Note that the latest public API is documented using JSDocs and is available in api.txt.
 #
 
+Version 0.71.7 {2b5649f2b8f13d52241959f613cbfdd7} 2019-07-29
+- Add static hasInstance as alternative instanceof implementation for AssetDeclaration, ClassDeclaration, EnumDeclaration, ConceptDeclaration, EnumValueDeclaration, Field, ModelFile, ModelManager, RelationshipDeclaration, TransactionDeclaration
+
 Version 0.70.5 {db48b7eb8404d9206e9bc8efb3de0009} 2019-06-23
 - Update exception triggered when creating EventDeclaration class
 

--- a/lib/introspect/assetdeclaration.js
+++ b/lib/introspect/assetdeclaration.js
@@ -37,6 +37,7 @@ class AssetDeclaration extends ClassDeclaration {
      */
     constructor(modelFile, ast) {
         super(modelFile, ast);
+        this._isAssetDeclaration = true;
     }
 
     /**
@@ -56,6 +57,17 @@ class AssetDeclaration extends ClassDeclaration {
     getSystemType() {
         let systemType = this.modelFile.getModelManager().getSystemModelTable().get('Asset');
         return systemType !== undefined ? systemType : null;
+    }
+
+    /**
+     * Alternative instanceof that is reliable across different module instances
+     * @see https://github.com/hyperledger/composer-concerto/issues/47
+     *
+     * @param {object} object - The object to test against
+     * @returns {boolean} - True, if the object is an instance of a AssetDeclaration
+     */
+    static [Symbol.hasInstance](object){
+        return typeof object !== 'undefined' && object !== null && Boolean(object._isAssetDeclaration);
     }
 }
 

--- a/lib/introspect/classdeclaration.js
+++ b/lib/introspect/classdeclaration.js
@@ -49,6 +49,7 @@ class ClassDeclaration extends Decorated {
         super(modelFile, ast);
         this.process();
         this.fqn = ModelUtil.getFullyQualifiedName(this.modelFile.getNamespace(), this.name);
+        this._isClassDeclaration = true;
     }
 
     /**
@@ -610,6 +611,17 @@ class ClassDeclaration extends Decorated {
             superType = ' super=' + this.superType;
         }
         return 'ClassDeclaration {id=' + this.getFullyQualifiedName() + superType + ' enum=' + this.isEnum() + ' abstract=' + this.isAbstract() + '}';
+    }
+
+    /**
+     * Alternative instanceof that is reliable across different module instances
+     * @see https://github.com/hyperledger/composer-concerto/issues/47
+     *
+     * @param {object} object - The object to test against
+     * @returns {boolean} - True, if the object is an instance of a Class Declaration
+     */
+    static [Symbol.hasInstance](object){
+        return typeof object !== 'undefined' && object !== null && Boolean(object._isClassDeclaration);
     }
 
 }

--- a/lib/introspect/conceptdeclaration.js
+++ b/lib/introspect/conceptdeclaration.js
@@ -37,6 +37,7 @@ class ConceptDeclaration extends ClassDeclaration {
      */
     constructor(modelFile, ast) {
         super(modelFile, ast);
+        this._isConceptDeclaration = true;
     }
 
     /**
@@ -46,6 +47,17 @@ class ConceptDeclaration extends ClassDeclaration {
      */
     isConcept() {
         return true;
+    }
+
+    /**
+     * Alternative instanceof that is reliable across different module instances
+     * @see https://github.com/hyperledger/composer-concerto/issues/47
+     *
+     * @param {object} object - The object to test against
+     * @returns {boolean} - True, if the object is an instance of a ConceptDeclaration
+     */
+    static [Symbol.hasInstance](object){
+        return typeof object !== 'undefined' && object !== null && Boolean(object._isConceptDeclaration);
     }
 }
 

--- a/lib/introspect/enumdeclaration.js
+++ b/lib/introspect/enumdeclaration.js
@@ -34,6 +34,7 @@ class EnumDeclaration extends ClassDeclaration {
      */
     constructor(modelFile, ast) {
         super(modelFile, ast);
+        this._isEnumDeclaration = true;
     }
 
     /**
@@ -51,6 +52,17 @@ class EnumDeclaration extends ClassDeclaration {
      */
     toString() {
         return 'EnumDeclaration {id=' + this.getFullyQualifiedName() + '}';
+    }
+
+    /**
+     * Alternative instanceof that is reliable across different module instances
+     * @see https://github.com/hyperledger/composer-concerto/issues/47
+     *
+     * @param {object} object - The object to test against
+     * @returns {boolean} - True, if the object is an instance of a Class Declaration
+     */
+    static [Symbol.hasInstance](object){
+        return typeof object !== 'undefined' && object !== null && Boolean(object._isEnumDeclaration);
     }
 }
 

--- a/lib/introspect/enumvaluedeclaration.js
+++ b/lib/introspect/enumvaluedeclaration.js
@@ -34,6 +34,7 @@ class EnumValueDeclaration extends Property {
      */
     constructor(parent, ast) {
         super(parent, ast);
+        this._isEnumValueDeclaration = true;
     }
 
     /**
@@ -44,6 +45,17 @@ class EnumValueDeclaration extends Property {
      */
     validate(classDecl) {
         super.validate(classDecl);
+    }
+
+    /**
+     * Alternative instanceof that is reliable across different module instances
+     * @see https://github.com/hyperledger/composer-concerto/issues/47
+     *
+     * @param {object} object - The object to test against
+     * @returns {boolean} - True, if the object is an instance of a EnumValueDeclaration
+     */
+    static [Symbol.hasInstance](object){
+        return typeof object !== 'undefined' && object !== null && Boolean(object._isEnumValueDeclaration);
     }
 }
 

--- a/lib/introspect/eventdeclaration.js
+++ b/lib/introspect/eventdeclaration.js
@@ -31,6 +31,7 @@ class EventDeclaration extends ClassDeclaration {
      */
     constructor(modelFile, ast) {
         super(modelFile, ast);
+        this._isEventDeclaration = true;
     }
 
     /**
@@ -61,6 +62,17 @@ class EventDeclaration extends ClassDeclaration {
      */
     isEvent() {
         return true;
+    }
+
+    /**
+     * Alternative instanceof that is reliable across different module instances
+     * @see https://github.com/hyperledger/composer-concerto/issues/47
+     *
+     * @param {object} object - The object to test against
+     * @returns {boolean} - True, if the object is an instance of a EventDeclaration
+     */
+    static [Symbol.hasInstance](object){
+        return typeof object !== 'undefined' && object !== null && Boolean(object._isEventDeclaration);
     }
 }
 

--- a/lib/introspect/field.js
+++ b/lib/introspect/field.js
@@ -38,6 +38,7 @@ class Field extends Property {
      */
     constructor(parent, ast) {
         super(parent, ast);
+        this._isField = true;
     }
 
     /**
@@ -99,6 +100,17 @@ class Field extends Property {
      */
     toString() {
         return 'Field {name=' + this.name + ', type=' + this.getFullyQualifiedTypeName() + ', array=' + this.array + ', optional=' + this.optional +'}';
+    }
+
+    /**
+     * Alternative instanceof that is reliable across different module instances
+     * @see https://github.com/hyperledger/composer-concerto/issues/47
+     *
+     * @param {object} object - The object to test against
+     * @returns {boolean} - True, if the object is an instance of a Class Declaration
+     */
+    static [Symbol.hasInstance](object){
+        return typeof object !== 'undefined' && object !== null && Boolean(object._isField);
     }
 }
 

--- a/lib/introspect/modelfile.js
+++ b/lib/introspect/modelfile.js
@@ -56,6 +56,7 @@ class ModelFile {
         this.importWildcardNamespaces = [];
         this.importUriMap = {};
         this.fileName = 'UNKNOWN';
+        this._isModelFile = true;
 
         if(!definitions || typeof definitions !== 'string') {
             throw new Error('ModelFile expects a Composer model as a string as input.');
@@ -609,6 +610,17 @@ class ModelFile {
      */
     isSystemModelFile() {
         return this.systemModelFile;
+    }
+
+    /**
+     * Alternative to instanceof that is reliable across different module instances
+     * @see https://github.com/hyperledger/composer-concerto/issues/47
+     *
+     * @param {object} object - The object to test against
+     * @returns {boolean} - True, if the object is an instance of a ModelFile
+     */
+    static [Symbol.hasInstance](object){
+        return typeof object !== 'undefined' && object !== null && Boolean(object._isModelFile);
     }
 }
 

--- a/lib/introspect/participantdeclaration.js
+++ b/lib/introspect/participantdeclaration.js
@@ -32,6 +32,7 @@ class ParticipantDeclaration extends ClassDeclaration {
      */
     constructor(modelFile, ast) {
         super(modelFile, ast);
+        this._isParticipantDeclaration = true;
     }
 
     /**
@@ -51,6 +52,17 @@ class ParticipantDeclaration extends ClassDeclaration {
     getSystemType() {
         let systemType = this.modelFile.getModelManager().getSystemModelTable().get('Participant');
         return systemType !== undefined ? systemType : null;
+    }
+
+    /**
+     * Alternative instanceof that is reliable across different module instances
+     * @see https://github.com/hyperledger/composer-concerto/issues/47
+     *
+     * @param {object} object - The object to test against
+     * @returns {boolean} - True, if the object is an instance of a ParticipantDeclaration
+     */
+    static [Symbol.hasInstance](object){
+        return typeof object !== 'undefined' && object !== null && Boolean(object._isParticipantDeclaration);
     }
 }
 

--- a/lib/introspect/property.js
+++ b/lib/introspect/property.js
@@ -36,6 +36,7 @@ class Property extends Decorated {
         super(parent.getModelFile(), ast);
         this.parent = parent;
         this.process();
+        this._isProperty = true;
     }
 
     /**
@@ -192,6 +193,16 @@ class Property extends Decorated {
         return ModelUtil.isPrimitiveType(this.getType());
     }
 
+    /**
+     * Alternative instanceof that is reliable across different module instances
+     * @see https://github.com/hyperledger/composer-concerto/issues/47
+     *
+     * @param {object} object - The object to test against
+     * @returns {boolean} - True, if the object is an instance of a Property
+     */
+    static [Symbol.hasInstance](object){
+        return typeof object !== 'undefined' && object !== null && Boolean(object._isProperty);
+    }
 }
 
 module.exports = Property;

--- a/lib/introspect/relationshipdeclaration.js
+++ b/lib/introspect/relationshipdeclaration.js
@@ -36,6 +36,7 @@ class RelationshipDeclaration extends Property {
      */
     constructor(parent, ast) {
         super(parent, ast);
+        this._isRelationshipDeclaration = true;
     }
 
     /**
@@ -91,6 +92,18 @@ class RelationshipDeclaration extends Property {
      */
     toString() {
         return 'RelationshipDeclaration {name=' + this.name + ', type=' + this.getFullyQualifiedTypeName() + ', array=' + this.array + ', optional=' + this.optional +'}';
-    }}
+    }
+
+    /**
+     * Alternative instanceof that is reliable across different module instances
+     * @see https://github.com/hyperledger/composer-concerto/issues/47
+     *
+     * @param {object} object - The object to test against
+     * @returns {boolean} - True, if the object is an instance of a RelationshipDeclaration
+     */
+    static [Symbol.hasInstance](object){
+        return typeof object !== 'undefined' && object !== null && Boolean(object._isRelationshipDeclaration);
+    }
+}
 
 module.exports = RelationshipDeclaration;

--- a/lib/introspect/transactiondeclaration.js
+++ b/lib/introspect/transactiondeclaration.js
@@ -32,6 +32,7 @@ class TransactionDeclaration extends ClassDeclaration {
      */
     constructor(modelFile, ast) {
         super(modelFile, ast);
+        this._isTransactionDeclaration = true;
     }
 
     /**
@@ -53,6 +54,17 @@ class TransactionDeclaration extends ClassDeclaration {
     getSystemType() {
         let systemType = this.modelFile.getModelManager().getSystemModelTable().get('Transaction');
         return systemType !== undefined ? systemType : null;
+    }
+
+    /**
+     * Alternative instanceof that is reliable across different module instances
+     * @see https://github.com/hyperledger/composer-concerto/issues/47
+     *
+     * @param {object} object - The object to test against
+     * @returns {boolean} - True, if the object is an instance of a TransactionDeclaration
+     */
+    static [Symbol.hasInstance](object){
+        return typeof object !== 'undefined' && object !== null && Boolean(object._isTransactionDeclaration);
     }
 }
 

--- a/lib/modelmanager.js
+++ b/lib/modelmanager.js
@@ -58,6 +58,7 @@ class ModelManager {
         this.serializer = new Serializer(this.factory, this);
         this.decoratorFactories = [];
         this.systemModelTable = new Map();
+        this._isModelManager = true;
     }
 
     /**
@@ -619,6 +620,16 @@ class ModelManager {
         this.decoratorFactories.push(factory);
     }
 
+    /**
+     * Alternative instanceof that is reliable across different module instances
+     * @see https://github.com/hyperledger/composer-concerto/issues/47
+     *
+     * @param {object} object - The object to test against
+     * @returns {boolean} - True, if the object is an instance of a ModelManager
+     */
+    static [Symbol.hasInstance](object){
+        return typeof object !== 'undefined' && object !== null && Boolean(object._isModelManager);
+    }
 }
 
 module.exports = ModelManager;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "composer-concerto",
-  "version": "0.71.6",
+  "version": "0.71.7",
   "description": "Concerto",
   "engines": {
     "node": ">=8",

--- a/test/introspect/assetdeclaration.js
+++ b/test/introspect/assetdeclaration.js
@@ -152,4 +152,22 @@ describe('AssetDeclaration', () => {
 
     });
 
+    describe('#hasInstance', () => {
+        it('should return true for a valid Asset Declaration', () => {
+            let asset = loadAssetDeclaration('test/data/parser/assetdeclaration.resolve.cto');
+            (asset instanceof AssetDeclaration).should.be.true;
+        });
+
+        it('should return true for a valid Asset Declaration using a different module instance', () => {
+            /* eslint-disable require-jsdoc */
+            class MyAssetDeclaration {
+                constructor(){
+                    this._isAssetDeclaration = true;
+                }
+            }
+            const asset = new MyAssetDeclaration();
+            (asset instanceof AssetDeclaration).should.be.true;
+        });
+    });
+
 });

--- a/test/introspect/enumdeclaration.js
+++ b/test/introspect/enumdeclaration.js
@@ -16,6 +16,7 @@
 
 const EnumDeclaration = require('../../lib/introspect/enumdeclaration');
 const EventDeclaration = require('../../lib/introspect/eventdeclaration');
+const EnumValueDeclaration = require('../../lib/introspect/enumvaluedeclaration');
 const ModelFile = require('../../lib/introspect/modelfile');
 const ModelManager = require('../../lib/modelmanager');
 const fs = require('fs');
@@ -73,6 +74,16 @@ describe('EnumDeclaration', () => {
         it('should give the correct value', () => {
             let declaration = loadLastDeclaration('test/data/model/enum.cto', EnumDeclaration);
             declaration.toString().should.equal('EnumDeclaration {id=org.acme.ConcreteEnum}');
+        });
+    });
+
+    describe('#hasInstance', () => {
+        it('should return true for a valid Enum Declaration', () => {
+            let declaration = loadLastDeclaration('test/data/model/enum.cto', EnumDeclaration);
+            (declaration instanceof EnumDeclaration).should.be.true;
+
+            let value = declaration.getProperties();
+            (value[0] instanceof EnumValueDeclaration).should.be.true;
         });
     });
 });

--- a/test/introspect/property.js
+++ b/test/introspect/property.js
@@ -85,4 +85,15 @@ describe('Property', () => {
 
     });
 
+    describe('#hasInstance', () => {
+        it('should return true for a valid Property', () => {
+            let p = new Property(mockClassDeclaration, {
+                id: {
+                    name: 'property',
+                }
+            });
+            (p instanceof Property).should.be.true;
+        });
+    });
+
 });

--- a/test/modelmanager.js
+++ b/test/modelmanager.js
@@ -1036,4 +1036,10 @@ concept Foo {
 
     });
 
+    describe('#hasInstance', () => {
+        it('should return true for a valid ModelManager', () => {
+            (modelManager instanceof ModelManager).should.be.true;
+        });
+    });
+
 });


### PR DESCRIPTION
Resolves #47 

Adds custom `instanceof` implementation through the use of [`Symbol.hasInstance`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/hasInstance) to allow comparison of different module instances. 
